### PR TITLE
Added line to make this work for USUM as well

### DIFF
--- a/pk3DS.Core/Game/GARCReference.cs
+++ b/pk3DS.Core/Game/GARCReference.cs
@@ -75,6 +75,7 @@ namespace pk3DS.Core
             new(193, "megaevo"),
             new(195, "personal"),
             new(197, "item"),
+            new(008, "models"),
 
             // Varied
             new(071, "gametext", true),

--- a/pk3DS.Core/Game/GARCReference.cs
+++ b/pk3DS.Core/Game/GARCReference.cs
@@ -144,8 +144,10 @@ namespace pk3DS.Core
             new(017, "personal"),
             new(019, "item"),
 
+
             new(077, "zonedata"),
             new(091, "worlddata"),
+            new(094, "models"),
 
             new(105, "trclass"),
             new(106, "trdata"),

--- a/pk3DS.Core/Game/GameConfig.cs
+++ b/pk3DS.Core/Game/GameConfig.cs
@@ -75,8 +75,6 @@ namespace pk3DS.Core
                     Files = GARCReference.GARCReference_XY;
                     Variables = TextVariableCode.VariableCodes_XY;
                     GameText = TextReference.GameText_XY;
-                    //set model pointer data length automatically
-                    //model_pointer_data_Length = 0xB48;
                     break;
 
                 case GameVersion.ORASDEMO:
@@ -84,8 +82,6 @@ namespace pk3DS.Core
                     Files = GARCReference.GARCReference_AO;
                     Variables = TextVariableCode.VariableCodes_AO;
                     GameText = TextReference.GameText_AO;
-                    //same for ORAS
-                    //model_pointer_data_Length = 0xB48;
                     break;
 
                 case GameVersion.SMDEMO:
@@ -110,8 +106,6 @@ namespace pk3DS.Core
                         Files = GARCReference.GARCReference_UM;
                     Variables = TextVariableCode.VariableCodes_SM;
                     GameText = TextReference.GameText_USUM;
-                    //USUM different than SM because new Pokemon, not just new Formes
-                    //model_pointer_data_Length = 0xCA0;
                     break;
             }
         }
@@ -134,133 +128,7 @@ namespace pk3DS.Core
             InitializeEvos();
             InitializeGameInfo();
 
-            //initialize array to stick read index numbers in
-            //string[] new_model_base_forme_indices_text = Array.Empty<string>();
-            //int[] new_model_base_forme_indices = Array.Empty<int>();
-
-            //text file names "changed_indices.txt" in the same directory as the built .exe
-            //var base_indices_path = Path.Combine(Directory.GetCurrentDirectory(), "changed_indices.txt");
-
-            //to skip everything below if file not found or file empty
-            //bool no_indices = false;
-            
-            //checks if file with list of indices exists
-            /*if (File.Exists(base_indices_path))
-            {
-                //try to read the file
-                try
-                {
-                    //grabs each line as a string (so put each index you want to change on a different line)
-                    new_model_base_forme_indices_text = File.ReadAllLines(base_indices_path);
-                }
-                catch
-                {
-                    no_indices = true;
-                }
-            }
-
-            if (!no_indices)
-            {
-                //Convert strings read from file into integers
-                new_model_base_forme_indices = Array.ConvertAll(new_model_base_forme_indices_text, int.Parse);
-
-                //Do the edits for each index number. This implementation is MUCH less computation-efficient than doing loops inside EditModelMasterTable,
-                //but it's not a lot and I don't understand what it's doing well enough to willingly much around with it.
-                foreach (var item in new_model_base_forme_indices)
-                {
-                    EditModelMasterTable(item);
-                }
-            }*/
         }
-        /*
-        public void EditModelMasterTable(int pokemonIndex)
-        {
-            GARCFile ModelFile = GetGARCData("models");
-            byte[] MasterTable = ModelFile.Files[0];
-
-
-            byte[] LimitedMT = new byte[model_pointer_data_Length];
-            Array.Copy(MasterTable, 0, LimitedMT, 0, model_pointer_data_Length);
-            //Console.WriteLine($"{BitConverter.ToString(MasterTable)}");
-            int size = 0x4;
-            byte[][] splitTable = PersonalTable.SplitBytes(LimitedMT, size);
-
-           // for (int i = 0; i < splitTable.Length; i++)
-           // {
-                Console.WriteLine($"Model[{i}]: {BitConverter.ToString(splitTable[i])}");
-          //  }
-
-            //edit pokemon's counts
-            int modelIndex = -1;
-            //form count, just do a plus-equal, for now just run Pokemon with more than 1 forme added through a second time. This avoids one set of accidental problems by substituting another (over-adding)
-            splitTable[pokemonIndex - 1][2] += 0x1;
-            //identifier, 0x1 = no extra forms, 0x3 = gender forms, 0x5 = non-gender forms, 0x7 = both gender and non-gender forms
-            //If splitTable[pokemonIndex - 1][3] is at least 0x5, it is already where we want, so don't modify. Otherwise it is 0x1 or 0x3, and we want to add 0x4 to get to 0x5 or 0x7, respectively.
-            if (splitTable[pokemonIndex - 1][3] < 0x5)
-            {
-                splitTable[pokemonIndex - 1][3] += 0x04;
-            }
-
-            int modelCount = 0;
-            for (int i = 0; i < splitTable.Length; i++)
-            {
-                if (i == pokemonIndex - 1)
-                {
-                    modelIndex = modelCount;
-                }
-                splitTable[i][0] = (byte)modelCount;
-                splitTable[i][1] = (byte)(modelCount >> 8);
-                modelCount += splitTable[i][2];
-            }
-
-            //for (int i = 0; i < splitTable.Length; i++)
-           // {
-                Console.WriteLine($"Model[{i}]: {BitConverter.ToString(splitTable[i])}");
-           // }
-
-            LimitedMT = splitTable.SelectMany(x => x).ToArray();
-            Array.Copy(LimitedMT, 0, MasterTable, 0, model_pointer_data_Length);
-
-            //Console.WriteLine($"modelcount: {modelCount}, mc * 2 - 2: {modelCount * 2 - 2}");
-            byte[] backhalfMT = new byte[modelCount * 2 - 2];
-            Array.Copy(MasterTable, model_pointer_data_Length, backhalfMT, 0, modelCount * 2 - 2);
-            //int backSize = 0x2;
-            //byte[][] splitBack = PersonalTable.SplitBytes(backhalfMT, backSize);
-
-            byte[] rewriteBackMT = new byte[modelCount * 2];
-            for (int i = 0, j = 0; i < modelCount * 2; i += 2, j += 2)
-            {
-                if (i / 2 == modelIndex)
-                {
-                    //this first byte would be 0x1 if its a female model
-                    //this doesn't apply here because we're only adding 2 bytes for megas and they're just set as 00 00
-                    //if you want to find the 2 bytes, use B48 + (2 * modelCount) at the index of your pokemon
-                    rewriteBackMT[i] = 0x0;
-                    rewriteBackMT[i + 1] = 0x0;
-                    j -= 2;
-                }
-                else
-                {
-                    rewriteBackMT[i] = backhalfMT[j];
-                    rewriteBackMT[i + 1] = backhalfMT[j + 1];
-                }
-            }
-            //Console.WriteLine($"First: {BitConverter.ToString(backhalfMT)}");
-            //Console.WriteLine($"Rewrt: {BitConverter.ToString(rewriteBackMT)}");
-
-            Array.Resize(ref MasterTable, model_pointer_data_Length + modelCount * 2);
-            Array.Copy(rewriteBackMT, 0, MasterTable, model_pointer_data_Length, modelCount * 2);
-
-            //Console.WriteLine($"Full Table: {BitConverter.ToString(MasterTable)}");
-
-            byte[][] modelReplace = ModelFile.Files;
-            modelReplace[0] = MasterTable;
-            ModelFile.Files = modelReplace;
-
-            //Console.WriteLine($"Full Table Again: {BitConverter.ToString(ModelFile.Files[0])}");
-            ModelFile.Save();
-        }
-        */
         public void InitializePersonal()
         {
             GARCPersonal = GetGARCData("personal");

--- a/pk3DS.Core/Game/GameConfig.cs
+++ b/pk3DS.Core/Game/GameConfig.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using pk3DS.Core.CTR;
 using pk3DS.Core.Structures.PersonalInfo;
 using pk3DS.Core.Structures;
+using System.Collections.Generic;
 
 namespace pk3DS.Core
 {
@@ -127,32 +128,43 @@ namespace pk3DS.Core
             InitializeGameInfo();
             // Don't uncomment this bit of code unless you know exactly what you're doing.
             // TODO Integrate this into the UI
-            //EditModelMasterTable();
+
+
+            //Uncomment & enter index numbers of edited base formes the below list
+            /*List<int> new_model_base_forme_indices = new List<int> { 1, 2, 3, 4, 5 };
+
+            foreach (var item in new_model_base_forme_indices)
+            {
+                EditModelMasterTable(item);
+            }*/
         }
 
-        public void EditModelMasterTable()
+        public void EditModelMasterTable(int pokemonIndex)
         {
             GARCFile ModelFile = GetGARCData("models");
             byte[] MasterTable = ModelFile.Files[0];
             int dataLength = 0xB48;
             byte[] LimitedMT = new byte[dataLength];
             Array.Copy(MasterTable, 0, LimitedMT, 0, dataLength);
-            //Console.WriteLine($"{BitConverter.ToString(MasterTable)}");
+            Console.WriteLine($"{BitConverter.ToString(MasterTable)}");
             int size = 0x4;
             byte[][] splitTable = PersonalTable.SplitBytes(LimitedMT, size);
 
-            /*for (int i = 0; i < splitTable.Length; i++)
+            for (int i = 0; i < splitTable.Length; i++)
             {
                 Console.WriteLine($"Model[{i}]: {BitConverter.ToString(splitTable[i])}");
-            }*/
+            }
 
             //edit pokemon's counts
-            int pokemonIndex = 384;
             int modelIndex = -1;
-            //form count
-            splitTable[pokemonIndex - 1][2] = 0x2;
+            //form count, just do a plus-equal, for now just run Pokemon with more than 1 forme added through a second time. This avoids one set of accidental problems by substituting another (over-adding)
+            splitTable[pokemonIndex - 1][2] += 0x1;
             //identifier, 0x1 = no extra forms, 0x3 = gender forms, 0x5 = non-gender forms, 0x7 = both gender and non-gender forms
-            splitTable[pokemonIndex - 1][3] = 0x5;
+            //If splitTable[pokemonIndex - 1][3] is at least 0x5, it is already where we want, so don't modify. Otherwise it is 0x1 or 0x3, and we want to add 0x4 to get to 0x5 or 0x7, respectively.
+            if splitTable[pokemonIndex - 1][3] < 0x5)
+            {
+                Math.Max(splitTable[pokemonIndex - 1][3]) += 0x04;
+            }
 
             int modelCount = 0;
             for (int i = 0; i < splitTable.Length; i++)

--- a/pk3DS.Core/Game/GameConfig.cs
+++ b/pk3DS.Core/Game/GameConfig.cs
@@ -133,17 +133,44 @@ namespace pk3DS.Core
             InitializeMoves();
             InitializeEvos();
             InitializeGameInfo();
-            // Don't uncomment this bit of code unless you know exactly what you're doing.
-            // TODO Integrate this into the UI
 
+            //initialize array to stick read index numbers in
+            string[] new_model_base_forme_indices_text = Array.Empty<string>();
+            int[] new_model_base_forme_indices = Array.Empty<int>();
 
-            //Uncomment & enter index numbers of edited base formes the below list
-            /*List<int> new_model_base_forme_indices = new List<int> { 497 };
+            //text file names "changed_indices.txt" in the same directory as the built .exe
+            var base_indices_path = Path.Combine(Directory.GetCurrentDirectory(), "changed_indices.txt");
 
-            foreach (var item in new_model_base_forme_indices)
+            //to skip everything below if file not found or file empty
+            bool no_indices = false;
+            
+            //checks if file with list of indices exists
+            if (File.Exists(base_indices_path))
             {
-                EditModelMasterTable(item);
-            }*/
+                //try to read the file
+                try
+                {
+                    //grabs each line as a string (so put each index you want to change on a different line)
+                    new_model_base_forme_indices_text = File.ReadAllLines(base_indices_path);
+                }
+                catch
+                {
+                    no_indices = true;
+                }
+            }
+
+            if (!no_indices)
+            {
+                //Convert strings read from file into integers
+                new_model_base_forme_indices = Array.ConvertAll(new_model_base_forme_indices_text, int.Parse);
+
+                //Do the edits for each index number. This implementation is MUCH less computation-efficient than doing loops inside EditModelMasterTable,
+                //but it's not a lot and I don't understand what it's doing well enough to willingly much around with it.
+                foreach (var item in new_model_base_forme_indices)
+                {
+                    EditModelMasterTable(item);
+                }
+            }
         }
 
         public void EditModelMasterTable(int pokemonIndex)
@@ -154,14 +181,14 @@ namespace pk3DS.Core
 
             byte[] LimitedMT = new byte[model_pointer_data_Length];
             Array.Copy(MasterTable, 0, LimitedMT, 0, model_pointer_data_Length);
-            Console.WriteLine($"{BitConverter.ToString(MasterTable)}");
+            //Console.WriteLine($"{BitConverter.ToString(MasterTable)}");
             int size = 0x4;
             byte[][] splitTable = PersonalTable.SplitBytes(LimitedMT, size);
 
-            for (int i = 0; i < splitTable.Length; i++)
+            /*for (int i = 0; i < splitTable.Length; i++)
             {
                 Console.WriteLine($"Model[{i}]: {BitConverter.ToString(splitTable[i])}");
-            }
+            }*/
 
             //edit pokemon's counts
             int modelIndex = -1;

--- a/pk3DS.Core/Game/GameConfig.cs
+++ b/pk3DS.Core/Game/GameConfig.cs
@@ -145,7 +145,7 @@ namespace pk3DS.Core
             bool no_indices = false;
             
             //checks if file with list of indices exists
-            if (File.Exists(base_indices_path))
+            /*if (File.Exists(base_indices_path))
             {
                 //try to read the file
                 try
@@ -170,7 +170,7 @@ namespace pk3DS.Core
                 {
                     EditModelMasterTable(item);
                 }
-            }
+            }*/
         }
 
         public void EditModelMasterTable(int pokemonIndex)

--- a/pk3DS.Core/Game/GameConfig.cs
+++ b/pk3DS.Core/Game/GameConfig.cs
@@ -76,7 +76,7 @@ namespace pk3DS.Core
                     Variables = TextVariableCode.VariableCodes_XY;
                     GameText = TextReference.GameText_XY;
                     //set model pointer data length automatically
-                    model_pointer_data_Length = 0xB48;
+                    //model_pointer_data_Length = 0xB48;
                     break;
 
                 case GameVersion.ORASDEMO:
@@ -85,7 +85,7 @@ namespace pk3DS.Core
                     Variables = TextVariableCode.VariableCodes_AO;
                     GameText = TextReference.GameText_AO;
                     //same for ORAS
-                    model_pointer_data_Length = 0xB48;
+                    //model_pointer_data_Length = 0xB48;
                     break;
 
                 case GameVersion.SMDEMO:
@@ -111,7 +111,7 @@ namespace pk3DS.Core
                     Variables = TextVariableCode.VariableCodes_SM;
                     GameText = TextReference.GameText_USUM;
                     //USUM different than SM because new Pokemon, not just new Formes
-                    model_pointer_data_Length = 0xCA0;
+                    //model_pointer_data_Length = 0xCA0;
                     break;
             }
         }
@@ -135,14 +135,14 @@ namespace pk3DS.Core
             InitializeGameInfo();
 
             //initialize array to stick read index numbers in
-            string[] new_model_base_forme_indices_text = Array.Empty<string>();
-            int[] new_model_base_forme_indices = Array.Empty<int>();
+            //string[] new_model_base_forme_indices_text = Array.Empty<string>();
+            //int[] new_model_base_forme_indices = Array.Empty<int>();
 
             //text file names "changed_indices.txt" in the same directory as the built .exe
-            var base_indices_path = Path.Combine(Directory.GetCurrentDirectory(), "changed_indices.txt");
+            //var base_indices_path = Path.Combine(Directory.GetCurrentDirectory(), "changed_indices.txt");
 
             //to skip everything below if file not found or file empty
-            bool no_indices = false;
+            //bool no_indices = false;
             
             //checks if file with list of indices exists
             /*if (File.Exists(base_indices_path))
@@ -172,7 +172,7 @@ namespace pk3DS.Core
                 }
             }*/
         }
-
+        /*
         public void EditModelMasterTable(int pokemonIndex)
         {
             GARCFile ModelFile = GetGARCData("models");
@@ -185,10 +185,10 @@ namespace pk3DS.Core
             int size = 0x4;
             byte[][] splitTable = PersonalTable.SplitBytes(LimitedMT, size);
 
-            /*for (int i = 0; i < splitTable.Length; i++)
-            {
+           // for (int i = 0; i < splitTable.Length; i++)
+           // {
                 Console.WriteLine($"Model[{i}]: {BitConverter.ToString(splitTable[i])}");
-            }*/
+          //  }
 
             //edit pokemon's counts
             int modelIndex = -1;
@@ -213,10 +213,10 @@ namespace pk3DS.Core
                 modelCount += splitTable[i][2];
             }
 
-            /*for (int i = 0; i < splitTable.Length; i++)
-            {
+            //for (int i = 0; i < splitTable.Length; i++)
+           // {
                 Console.WriteLine($"Model[{i}]: {BitConverter.ToString(splitTable[i])}");
-            }*/
+           // }
 
             LimitedMT = splitTable.SelectMany(x => x).ToArray();
             Array.Copy(LimitedMT, 0, MasterTable, 0, model_pointer_data_Length);
@@ -260,7 +260,7 @@ namespace pk3DS.Core
             //Console.WriteLine($"Full Table Again: {BitConverter.ToString(ModelFile.Files[0])}");
             ModelFile.Save();
         }
-
+        */
         public void InitializePersonal()
         {
             GARCPersonal = GetGARCData("personal");

--- a/pk3DS/Main.cs
+++ b/pk3DS/Main.cs
@@ -755,44 +755,6 @@ namespace pk3DS
             {
                 byte[][] d = Config.GARCPersonal.Files;
 
-                // Don't uncomment any of the below code unless you know exactly what you're doing.
-
-                //Add new pokemon to pokemon info list
-                /*byte[][] d2 = new byte[d.Length + 1][];
-                for (int i = 0; i < d2.Length - 1; i++)
-                {
-                    d2[i] = d[i];
-                }
-                //The details for mega rayquaza
-                string s = "69 B4 64 73 B4 64 0F 02 2D 03 08 01 00 00 00 00 00 00 FF 78 00 05 0F 0F 01 01 01 00 00 00 00 00 02 03 5F 01 38 04 50 0F B3 76 B3 C7 F4 8A 9B 06 49 B7 C2 22 E8 07 00 00 C0 00 00 00 2F 01 02 00";
-                string[] s2 = s.Split(' ');
-                //Console.WriteLine($"s2 result: {string.Join(", ", s2)}");
-                d2[d2.Length - 2] = s2.Select(x => Convert.ToByte(x, 16)).ToArray();
-                //Console.WriteLine($"s output: {BitConverter.ToString(d2[d2.Length - 2])}");
-                d2[d2.Length - 1] = d2.Where(x => x != null).SelectMany(x => x).ToArray();
-
-                Config.GARCPersonal.FileCount = d.Length + 1;
-                Config.GARCPersonal.Files = d2;
-                Config.GARCPersonal.Save();
-                d = Config.GARCPersonal.Files;
-                
-                System.Diagnostics.Debug.WriteLine($"Pokemon[{d.Length - 2}]: {BitConverter.ToString(d[d.Length - 2])}");*/
-
-                /*for (int i = 0; i < d.Length; i++)
-                {
-                    Console.WriteLine($"Pokemon[{i}]: {BitConverter.ToString(d[i])}");
-                }
-                for (int i = 0; i < d2.Length; i++)
-                {
-                    Console.WriteLine($"Pokemon2[{i}]: {BitConverter.ToString(d2[i])}");
-                }
-
-                //For just printing out the personal list
-                for (int i = 0; i < d.Length; i++)
-                {
-                    Console.WriteLine($"Pokemon[{i}]: {BitConverter.ToString(d[i])}");
-                }*/
-
                 switch (Config.Generation)
                 {
                     case 6:

--- a/pk3DS/Subforms/Gen6/EvolutionEditor6.cs
+++ b/pk3DS/Subforms/Gen6/EvolutionEditor6.cs
@@ -24,8 +24,8 @@ namespace pk3DS
 
             specieslist[0] = movelist[0] = itemlist[0] = "";
             Array.Resize(ref specieslist, Main.Config.MaxSpeciesID + 1);
-            string[][] AltForms = Main.Config.Personal.GetFormList(specieslist, Main.Config.MaxSpeciesID);
-            specieslist = Main.Config.Personal.GetPersonalEntryList(AltForms, specieslist, Main.Config.MaxSpeciesID, out baseForms, out formVal);
+            string[][] AltForms = Main.Config.Personal.GetFormList(specieslist, Main.Config.MaxSpeciesID); // Include all forms, not just base form
+            specieslist = Main.Config.Personal.GetPersonalEntryList(AltForms, specieslist, Main.Config.MaxSpeciesID, out baseForms, out formVal); // baseForms and formVal added as int on line 95
 
             string[] evolutionMethods =
             {

--- a/pk3DS/Subforms/Gen6/EvolutionEditor6.cs
+++ b/pk3DS/Subforms/Gen6/EvolutionEditor6.cs
@@ -24,6 +24,8 @@ namespace pk3DS
 
             specieslist[0] = movelist[0] = itemlist[0] = "";
             Array.Resize(ref specieslist, Main.Config.MaxSpeciesID + 1);
+            string[][] AltForms = Main.Config.Personal.GetFormList(specieslist, Main.Config.MaxSpeciesID);
+            specieslist = Main.Config.Personal.GetPersonalEntryList(AltForms, specieslist, Main.Config.MaxSpeciesID, out baseForms, out formVal);
 
             string[] evolutionMethods =
             {
@@ -90,6 +92,7 @@ namespace pk3DS
         private readonly string[] itemlist = Main.Config.GetText(TextName.ItemNames);
         private readonly string[] typelist = Main.Config.GetText(TextName.Types);
         private bool dumping;
+        private readonly int[] baseForms, formVal;
         private EvolutionSet evo = new EvolutionSet6(new byte[EvolutionSet6.SIZE]);
 
         private void GetList()


### PR DESCRIPTION
1. Automated detection of game (XY/ORAS/USUM) to set the appropriate table size (need to get copy of SM to get confirm correct table size value).
2. Now does not to be recompiled per Pokemon. Instead, on load it looks for changed_indices.txt. For each pokemon with a new forme-model inserted, their nat dex number should be entered on a new line per model. If the file is empty or non-existent, this will not run. If multiple models were added (e.g. Mega X and Mega Y), the nat dex should be entered twice.

e,g, if you added Serperior X, Serperior Y, and Hisuian Decidueye, the file should read

497
497
724